### PR TITLE
Fix query string hash with false parameters

### DIFF
--- a/src/Http/Auth/QSH.php
+++ b/src/Http/Auth/QSH.php
@@ -192,12 +192,9 @@ class QSH
         $pieces = [];
 
         foreach ($this->encodeQueryParams($params) as $param => $values) {
-            $value = implode(',', $values);
-
-            $pieces[] = implode('=', !$value
-                ? [$param]
-                : [$param, $value]
-            );
+            $pieces[] = $values
+                ? implode('=', [$param, implode(',', $values)])
+                : $param;
         }
 
         return implode('&', array_filter($pieces));

--- a/tests/Auth/QSHTest.php
+++ b/tests/Auth/QSHTest.php
@@ -61,6 +61,10 @@ class QSHTest extends \AtlassianConnectCore\Tests\TestCase
         $this->assertCanonicalQuery('a=x1&a=x10&b=y1&b=y10', 'a=x1,x10&b=y1,y10');
         $this->assertCanonicalQuery('a=another+one&a=one+string&b=and+yet+more&b=more+here', 'a=another%20one,one%20string&b=and%20yet%20more,more%20here');
         $this->assertCanonicalQuery('a=1%2C2%2C3&a=4%2C5%2C6&b=a%2Cb%2Cc&b=d%2Ce%2Cf', 'a=1%2C2%2C3,4%2C5%2C6&b=a%2Cb%2Cc,d%2Ce%2Cf');
+
+        // Parameter values that might evaluate weirdly in PHP
+        $this->assertCanonicalQuery('empty=', 'empty=');
+        $this->assertCanonicalQuery('since=0', 'since=0');
     }
 
     /**


### PR DESCRIPTION
When using the JWTClient to send a query with a parameter that has a value of '' or '0', the QSH and resulting JWT signature doesn't match and Atlassian rejects it with a 401.

An example might be using `/rest/api/3/worklog/updated?since=0` to retrieve worklogs updated since the beginning of time. The current code to handle parameter-only query strings will accidentally activate on strings that are considered false in PHP, so it will be treated like it's just `since`. As a result, it hashes `GET&/rest/api/3/worklog/updated&since` instead of the expected `GET&/rest/api/3/worklog/updated&since=0`. The same problem also occurs if you send an empty parameter, like `properties=`.

This PR fixes the code to properly differentiate between `?param`, `?param=` and `?param=0` and adds some tests for these cases. According to the [PHP docs on boolean casting](https://www.php.net/manual/en/language.types.boolean.php#language.types.boolean.casting), there shouldn't be any other string values that are considered false, so I think these tests are enough.